### PR TITLE
2199785 - [PS cmdlet] New-AzsPlan : RGName should not be mandatory in…

### DIFF
--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
@@ -55,7 +55,6 @@ function Get-AzsManagedOffer
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_List')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Offers_Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Get')]
         [System.String]
         $ResourceGroupName,

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
@@ -54,7 +54,6 @@ function Get-AzsOfferDelegation {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
@@ -40,7 +40,6 @@ function Get-AzsPlan
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Plans_List')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Plans_Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Plans_Get')]
         [ValidateNotNull()]
         [System.String]

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
@@ -33,9 +33,7 @@ function Remove-AzsOffer
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Offers_Delete')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Delete')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_Offers_Delete')]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
@@ -41,8 +41,6 @@ function Remove-AzsOfferDelegation
         [System.String]
         $OfferName,
         
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_OfferDelegations_Delete')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_OfferDelegations_Delete')]
         [Parameter(Mandatory = $true, ParameterSetName = 'OfferDelegations_Delete')]
         [System.String]
         $ResourceGroupName,

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
@@ -33,9 +33,7 @@ function Remove-AzsPlan
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Plans_Delete')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Plans_Delete')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_Plans_Delete')]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
@@ -59,8 +59,6 @@ function Set-AzsOffer
         [System.String]
         $Name,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Offers_CreateOrUpdate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_Offers_CreateOrUpdate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_CreateOrUpdate')]
         [System.String]
         $ResourceGroupName,

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
@@ -46,8 +46,6 @@ function Set-AzsOfferDelegation
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'OfferDelegations_CreateOrUpdate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_OfferDelegations_CreateOrUpdate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_OfferDelegations_CreateOrUpdate')]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
@@ -54,8 +54,6 @@ function Set-AzsPlan
         $Name,
     
         [Parameter(Mandatory = $true, ParameterSetName = 'Plans_CreateOrUpdate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId_Plans_CreateOrUpdate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InputObject_Plans_CreateOrUpdate')]
         [System.String]
         $ResourceGroupName,
 


### PR DESCRIPTION
… ResourceId_Plans_CreateOrUpdate parameter set

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [ ] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#making-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [ ] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)