### PR TITLE
Fixing Bug [PS cmdlet] Add [ValidateLength(1, 90)] for resourcegroup parameter name

### DIFF
--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeActivation.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeActivation.ps1
@@ -48,6 +48,7 @@ function Get-AzsAzureBridgeActivation {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeDownloadedProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeDownloadedProduct.ps1
@@ -56,6 +56,7 @@ function Get-AzsAzureBridgeDownloadedProduct {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeProduct.ps1
@@ -56,6 +56,7 @@ function Get-AzsAzureBridgeProduct {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Invoke-AzsAzureBridgeProductDownload.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Invoke-AzsAzureBridgeProductDownload.ps1
@@ -40,6 +40,7 @@ function Invoke-AzsAzureBridgeProductDownload {
         $ProductName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Products_Download')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAzureBridgeDownloadedProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAzureBridgeDownloadedProduct.ps1
@@ -42,6 +42,7 @@ function Remove-AzsAzureBridgeDownloadedProduct {
         $ActivationName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackup.ps1
@@ -75,6 +75,7 @@ function Get-AzsBackup {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackupLocation.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackupLocation.ps1
@@ -77,6 +77,7 @@ function Get-AzsBackupLocation {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsBackup.ps1
@@ -44,6 +44,7 @@ function Restore-AzsBackup {
     [CmdletBinding(DefaultParameterSetName = 'Backups_Restore')]
     param(
         [Parameter(Mandatory = $false, ParameterSetName = 'Backups_Restore')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
@@ -84,6 +84,7 @@ function Set-AzsBackupShare {
         $ResourceId,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Update')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsBackup.ps1
@@ -54,6 +54,7 @@ function Start-AzsBackup {
     [CmdletBinding(DefaultParameterSetName = 'CreateBackup')]
     param(
         [Parameter(Mandatory = $false, ParameterSetName = 'CreateBackup')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsScaleUnitNode.ps1
@@ -55,6 +55,7 @@ function Add-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ScaleOut')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsInfrastructureRoleInstance.ps1
@@ -42,6 +42,7 @@ function Suspend-AzsInfrastructureRoleInstance {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Shutdown')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsScaleUnitNode.ps1
@@ -41,6 +41,7 @@ function Disable-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Disable')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Enable-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Enable-AzsScaleUnitNode.ps1
@@ -41,6 +41,7 @@ function Enable-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Enable')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGateway.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGateway.ps1
@@ -68,6 +68,7 @@ function Get-AzsEdgeGateway {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGatewayPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGatewayPool.ps1
@@ -68,6 +68,7 @@ function Get-AzsEdgeGatewayPool {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureLocation.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureLocation.ps1
@@ -48,6 +48,7 @@ function Get-AzsInfrastructureLocation {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRole.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRole.ps1
@@ -72,6 +72,7 @@ function Get-AzsInfrastructureRole {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRoleInstance.ps1
@@ -75,6 +75,7 @@ function Get-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureShare.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureShare.ps1
@@ -65,6 +65,7 @@ function Get-AzsInfrastructureShare {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureVolume.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureVolume.ps1
@@ -84,6 +84,7 @@ function Get-AzsInfrastructureVolume {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsIpPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsIpPool.ps1
@@ -74,6 +74,7 @@ function Get-AzsIpPool {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalNetwork.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalNetwork.ps1
@@ -70,6 +70,7 @@ function Get-AzsLogicalNetwork {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalSubnet.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalSubnet.ps1
@@ -75,6 +75,7 @@ function Get-AzsLogicalSubnet {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsMacAddressPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsMacAddressPool.ps1
@@ -68,6 +68,7 @@ function Get-AzsMacAddressPool {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnit.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnit.ps1
@@ -69,6 +69,7 @@ function Get-AzsScaleUnit {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnitNode.ps1
@@ -70,6 +70,7 @@ function Get-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSlbMuxInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSlbMuxInstance.ps1
@@ -69,6 +69,7 @@ function Get-AzsSlbMuxInstance {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStoragePool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStoragePool.ps1
@@ -77,6 +77,7 @@ function Get-AzsStoragePool {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageSystem.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageSystem.ps1
@@ -69,6 +69,7 @@ function Get-AzsStorageSystem {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsIpPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsIpPool.ps1
@@ -63,6 +63,7 @@ function New-AzsIpPool {
         $Location,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Repair-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Repair-AzsScaleUnitNode.ps1
@@ -48,6 +48,7 @@ function Repair-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Repair')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRole.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRole.ps1
@@ -41,6 +41,7 @@ function Restart-AzsInfrastructureRole {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Restart')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRoleInstance.ps1
@@ -44,6 +44,7 @@ function Restart-AzsInfrastructureRoleInstance {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Reboot')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsInfrastructureRoleInstance.ps1
@@ -43,6 +43,7 @@ function Start-AzsInfrastructureRoleInstance {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'PowerOn')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
@@ -43,6 +43,7 @@ function Start-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'PowerOn')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsInfrastructureRoleInstance.ps1
@@ -43,6 +43,7 @@ function Stop-AzsInfrastructureRoleInstance {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'PowerOff')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsScaleUnitNode.ps1
@@ -54,6 +54,7 @@ function Stop-AzsScaleUnitNode {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Stop')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Close-AzsAlert.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Close-AzsAlert.ps1
@@ -113,6 +113,7 @@ function Close-AzsAlert {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Close')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAlert.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAlert.ps1
@@ -93,6 +93,7 @@ function Get-AzsAlert {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRPHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRPHealth.ps1
@@ -92,6 +92,7 @@ function Get-AzsRPHealth {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegionHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegionHealth.ps1
@@ -53,6 +53,7 @@ function Get-AzsRegionHealth {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegistrationHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegistrationHealth.ps1
@@ -130,6 +130,7 @@ function Get-AzsRegistrationHealth {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobService.ps1
@@ -36,6 +36,7 @@ function Get-AzsBlobService {
         $FarmName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetric.ps1
@@ -55,6 +55,7 @@ function Get-AzsBlobServiceMetric {
         $FarmName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ListMetrics')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetricDefinition.ps1
@@ -56,6 +56,7 @@ function Get-AzsBlobServiceMetricDefinition {
         $FarmName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ListMetricDefinitions')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDestinationShare.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDestinationShare.ps1
@@ -38,6 +38,7 @@ function Get-AzsDestinationShare {
         $FarmName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ListDestinationShares')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueService.ps1
@@ -36,6 +36,7 @@ function Get-AzsQueueService {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetric.ps1
@@ -53,6 +53,7 @@ function Get-AzsQueueServiceMetric {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetricDefinition.ps1
@@ -52,6 +52,7 @@ function Get-AzsQueueServiceMetricDefinition {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsReclaimStorageCapacityStatus.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsReclaimStorageCapacityStatus.ps1
@@ -38,6 +38,7 @@ function Get-AzsReclaimStorageCapacityStatus {
         $JobId,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'GetGarbageCollectionState')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAccount.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAccount.ps1
@@ -82,6 +82,7 @@ function Get-AzsStorageAccount {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAcquisition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAcquisition.ps1
@@ -33,6 +33,7 @@ function Get-AzsStorageAcquisition {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainer.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainer.ps1
@@ -56,6 +56,7 @@ function Get-AzsStorageContainer {
         $ShareName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainerMigration.ps1
@@ -52,6 +52,7 @@ function Get-AzsStorageContainerMigrationStatus {
         $JobId,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'MigrationStatus')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarm.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarm.ps1
@@ -46,6 +46,7 @@ function Get-AzsStorageFarm {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetric.ps1
@@ -48,6 +48,7 @@ function Get-AzsStorageFarmMetric {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetricDefinition.ps1
@@ -47,6 +47,7 @@ function Get-AzsStorageFarmMetricDefinition {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShare.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShare.ps1
@@ -49,6 +49,7 @@ function Get-AzsStorageShare {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetric.ps1
@@ -52,6 +52,7 @@ function Get-AzsStorageShareMetric {
         $ShareName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetricDefinition.ps1
@@ -52,6 +52,7 @@ function Get-AzsStorageShareMetricDefinition {
         $ShareName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableService.ps1
@@ -35,6 +35,7 @@ function Get-AzsTableService {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetric.ps1
@@ -62,6 +62,7 @@ function Get-AzsTableServiceMetric {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetricDefinition.ps1
@@ -63,6 +63,7 @@ function Get-AzsTableServiceMetricDefinition {
         $FarmName,
 
         [Parameter(Mandatory = $false)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsStorageAccount.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsStorageAccount.ps1
@@ -44,6 +44,7 @@ function Restore-AzsStorageAccount {
         $AccountId,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Undelete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsReclaimStorageCapacity.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsReclaimStorageCapacity.ps1
@@ -32,6 +32,7 @@ function Start-AzsReclaimStorageCapacity {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsStorageContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsStorageContainerMigration.ps1
@@ -54,6 +54,7 @@ function Start-AzsStorageContainerMigration {
         $ShareName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Migrate')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsContainerMigration.ps1
@@ -39,6 +39,7 @@ function Stop-AzsContainerMigration {
         $JobId,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'CancelMigration')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Connect-AzsPlanToOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Connect-AzsPlanToOffer.ps1
@@ -44,6 +44,7 @@ function Add-AzsPlanToOffer
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Link')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disconnect-AzsPlanToOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disconnect-AzsPlanToOffer.ps1
@@ -44,6 +44,7 @@ function Remove-AzsPlanFromOffer
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Unlink')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDirectoryTenant.ps1
@@ -53,6 +53,7 @@ function Get-AzsDirectoryTenant {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
@@ -55,6 +55,7 @@ function Get-AzsManagedOffer {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
@@ -56,6 +56,7 @@ function Get-AzsOfferDelegation {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetric.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetric.ps1
@@ -35,6 +35,7 @@ function Get-AzsOfferMetric {
         $OfferName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetricDefinition.ps1
@@ -31,6 +31,7 @@ function Get-AzsOfferMetricDefinition {
         $OfferName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
@@ -44,6 +44,7 @@ function Get-AzsPlan {
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [ValidateNotNull()]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetric.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetric.ps1
@@ -27,6 +27,7 @@ function Get-AzsPlanMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetricDefinition.ps1
@@ -31,6 +31,7 @@ function Get-AzsPlanMetricDefinition {
         $PlanName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsDirectoryTenant.ps1
@@ -53,6 +53,7 @@ function New-AzsDirectoryTenant {
         $TenantId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOffer.ps1
@@ -77,6 +77,7 @@ function New-AzsOffer {
         $DisplayName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_CreateOrUpdate')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOfferDelegation.ps1
@@ -56,6 +56,7 @@ function New-AzsOfferDelegation {
         $SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsPlan.ps1
@@ -67,6 +67,7 @@ function New-AzsPlan {
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsDirectoryTenant.ps1
@@ -37,6 +37,7 @@ function Remove-AzsDirectoryTenant {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
@@ -36,6 +36,7 @@ function Remove-AzsOffer {
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
@@ -43,6 +43,7 @@ function Remove-AzsOfferDelegation {
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
@@ -36,6 +36,7 @@ function Remove-AzsPlan {
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsDirectoryTenant.ps1
@@ -41,6 +41,7 @@ function Set-AzsDirectoryTenant
         [Parameter(Mandatory = $true, ParameterSetName = 'InputObject')]
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
@@ -79,6 +79,7 @@ function Set-AzsOffer
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
@@ -58,6 +58,7 @@ function Set-AzsOfferDelegation
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
@@ -73,6 +73,7 @@ function Set-AzsPlan
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdate.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdate.ps1
@@ -74,6 +74,7 @@ function Get-AzsUpdate {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateLocation.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateLocation.ps1
@@ -46,6 +46,7 @@ function Get-AzsUpdateLocation {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateRun.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateRun.ps1
@@ -73,6 +73,7 @@ function Get-AzsUpdateRun {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'List')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Get')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Install-AzsUpdate.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Install-AzsUpdate.ps1
@@ -54,6 +54,7 @@ function Install-AzsUpdate {
     [CmdletBinding(DefaultParameterSetName = 'Apply')]
     param(
         [Parameter(Mandatory = $false, ParameterSetName = 'Apply')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsUpdateRun.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsUpdateRun.ps1
@@ -43,6 +43,7 @@ function Restart-AzsUpdateRun {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'UpdateRuns_Rerun')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Resume-AzsUpdateRun.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Resume-AzsUpdateRun.ps1
@@ -44,6 +44,7 @@ function Resume-AzsUpdateRun {
         $Location,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'UpdateRuns_Rerun')]
+        [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,
 


### PR DESCRIPTION
Adding ValidateLength to resource group parameter name

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [ ] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#making-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [ ] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)