### PR TITLE
Add check for not null or empty for mandatory parameters; Adding alias for location in subscription admin module

### DIFF
--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeActivation.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeActivation.ps1
@@ -43,17 +43,20 @@ function Get-AzsAzureBridgeActivation {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeDownloadedProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeDownloadedProduct.ps1
@@ -46,22 +46,26 @@ function Get-AzsAzureBridgeDownloadedProduct {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ActivationName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAzureBridgeProduct.ps1
@@ -46,22 +46,26 @@ function Get-AzsAzureBridgeProduct {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ActivationName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Invoke-AzsAzureBridgeProductDownload.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Invoke-AzsAzureBridgeProductDownload.ps1
@@ -32,20 +32,24 @@ function Invoke-AzsAzureBridgeProductDownload {
     [CmdletBinding(DefaultParameterSetName = 'Products_Download')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Products_Download')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ActivationName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Products_Download')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ProductName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Products_Download')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAzureBridgeDownloadedProduct.ps1
+++ b/src/StackAdmin/Azs.AzureBridge.Admin/Module/Azs.AzureBridge.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAzureBridgeDownloadedProduct.ps1
@@ -34,15 +34,18 @@ function Remove-AzsAzureBridgeDownloadedProduct {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ActivationName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
@@ -52,6 +55,7 @@ function Remove-AzsAzureBridgeDownloadedProduct {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackup.ps1
@@ -40,6 +40,7 @@ function Get-AzsBackup {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Get-AzsBackup {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
@@ -60,6 +62,7 @@ function Get-AzsBackup {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'ParentObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Backup.Admin.Models.BackupLocation]
         $ParentObject,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackupLocation.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBackupLocation.ps1
@@ -43,6 +43,7 @@ function Get-AzsBackupLocation {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsBackup.ps1
@@ -35,6 +35,7 @@ function Restore-AzsBackup {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Backups_Restore')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Backup,
 
@@ -44,6 +45,7 @@ function Restore-AzsBackup {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
@@ -49,11 +49,13 @@ function Set-AzsBackupShare {
     [CmdletBinding(DefaultParameterSetName = 'Update')]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Backup.Admin.Models.BackupLocation]
         $InputObject,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsBackup.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsBackup.ps1
@@ -38,6 +38,7 @@ function Start-AzsBackup {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'CreateBackup_FromResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Backup.Admin/Tests/SessionRecords/BackupAdminClient/TestUpdateBackupLocation.json
+++ b/src/StackAdmin/Azs.Backup.Admin/Tests/SessionRecords/BackupAdminClient/TestUpdateBackupLocation.json
@@ -68,7 +68,7 @@
       "RequestUri": "/subscriptions/8158498d-27b1-4ccf-9aa1-de0f925731e6/resourcegroups/System.local/providers/Microsoft.Backup.Admin/backupLocations/local?api-version=2016-05-01",
       "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODE1ODQ5OGQtMjdiMS00Y2NmLTlhYTEtZGUwZjkyNTczMWU2L3Jlc291cmNlZ3JvdXBzL1N5c3RlbS5sb2NhbC9wcm92aWRlcnMvTWljcm9zb2Z0LkJhY2t1cC5BZG1pbi9iYWNrdXBMb2NhdGlvbnMvbG9jYWw/YXBpLXZlcnNpb249MjAxNi0wNS0wMQ==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"externalStoreDefault\": {\r\n      \"path\": \"\\\\\\\\su1fileserver\\\\SU1_Infrastructure_3\",\r\n      \"userName\": \"AzureStack\\\\AzureStackAdmin\",\r\n      \"password\": \"password\",\r\n      \"encryptionKeyBase64\": \"YVVOa0J3S2xTamhHZ1lyRU9wQ1pKQ0xWanhjaHlkaU5ZQnNDeHRPTGFQenJKdWZsRGtYT25oYmlaa1RMVWFKeQ==\",\r\n      \"backupFrequencyInHours\": \"\",\r\n      \"availableCapacity\": \"10GB\",\r\n      \"isBackupSchedulerEnabled\": false\r\n    }\r\n  },\r\n  \"location\": \"local\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"externalStoreDefault\": {\r\n      \"path\": \"\\\\\\\\192.168.1.1\\\\Share\",\r\n      \"userName\": \"AzureStack\\\\AzureStackAdmin\",\r\n      \"password\": \"password\",\r\n      \"encryptionKeyBase64\": \"YVVOa0J3S2xTamhHZ1lyRU9wQ1pKQ0xWanhjaHlkaU5ZQnNDeHRPTGFQenJKdWZsRGtYT25oYmlaa1RMVWFKeQ==\",\r\n      \"backupFrequencyInHours\": \"\",\r\n      \"availableCapacity\": \"10GB\",\r\n      \"isBackupSchedulerEnabled\": false\r\n    }\r\n  },\r\n  \"location\": \"local\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -87,7 +87,7 @@
           "Microsoft.AzureStack.Management.Backup.Admin.BackupAdminClient/0.1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/8158498d-27b1-4ccf-9aa1-de0f925731e6/resourcegroups/System.local/providers/Microsoft.Backup.Admin/backupLocations/local\",\r\n  \"name\": \"local\",\r\n  \"type\": \"Microsoft.Backup.Admin/backupLocations\",\r\n  \"location\": \"local\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"externalStoreDefault\": {\r\n      \"path\": \"\\\\\\\\su1fileserver\\\\SU1_Infrastructure_3\",\r\n      \"userName\": \"AzureStack\\\\AzureStackAdmin\",\r\n      \"password\": \"\",\r\n      \"encryptionKeyBase64\": \"\",\r\n      \"backupFrequencyInHours\": \"\",\r\n      \"availableCapacity\": \"10GB\",\r\n      \"isBackupSchedulerEnabled\": false,\r\n      \"nextBackupTime\": null,\r\n      \"lastBackupTime\": null\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/8158498d-27b1-4ccf-9aa1-de0f925731e6/resourcegroups/System.local/providers/Microsoft.Backup.Admin/backupLocations/local\",\r\n  \"name\": \"local\",\r\n  \"type\": \"Microsoft.Backup.Admin/backupLocations\",\r\n  \"location\": \"local\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"externalStoreDefault\": {\r\n      \"path\": \"\\\\\\\\192.168.1.1\\\\Share\",\r\n      \"userName\": \"AzureStack\\\\AzureStackAdmin\",\r\n      \"password\": \"\",\r\n      \"encryptionKeyBase64\": \"\",\r\n      \"backupFrequencyInHours\": \"\",\r\n      \"availableCapacity\": \"10GB\",\r\n      \"isBackupSchedulerEnabled\": false,\r\n      \"nextBackupTime\": null,\r\n      \"lastBackupTime\": null\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "523"

--- a/src/StackAdmin/Azs.Commerce.Admin/Module/Azs.Commerce.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscriberUsage.ps1
+++ b/src/StackAdmin/Azs.Commerce.Admin/Module/Azs.Commerce.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscriberUsage.ps1
@@ -47,6 +47,7 @@ function Get-AzsSubscriberUsage {
         $SubscriberId,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.DateTime]
         $ReportedStartTime,
 
@@ -60,6 +61,7 @@ function Get-AzsSubscriberUsage {
         $Skip = -1,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.DateTime]
         $ReportedEndTime,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsPlatformImage.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsPlatformImage.ps1
@@ -55,26 +55,32 @@ function Add-AzsPlatformImage {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Offer,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Sku,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Unknown', 'Windows', 'Linux')]
+        [ValidateNotNullOrEmpty()]
         $OsType,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OsUri,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsVMExtension.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsVMExtension.ps1
@@ -55,27 +55,33 @@ function Add-AzsVMExtension {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Type,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         $SourceBlob,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("Unknown", "Windows", "Linux")]
+        [ValidateNotNullOrEmpty()]
         $VmOsType,
 
         [Parameter(Mandatory = $true)]
         [string]
         [ValidateSet('IaaS', 'PaaS')]
+        [ValidateNotNullOrEmpty()]
         $ComputeRole,
 
         [Parameter(Mandatory = $false)]

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsComputeQuota.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsComputeQuota.ps1
@@ -40,6 +40,7 @@ function Get-AzsComputeQuota {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Get-AzsComputeQuota {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlatformImage.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlatformImage.ps1
@@ -49,18 +49,22 @@ function Get-AzsPlatformImage {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Offer,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Sku,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
@@ -71,6 +75,7 @@ function Get-AzsPlatformImage {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsVMExtension.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsVMExtension.ps1
@@ -43,14 +43,17 @@ function Get-AzsVMExtension {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Type,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
@@ -61,6 +64,7 @@ function Get-AzsVMExtension {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsComputeQuota.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsComputeQuota.ps1
@@ -46,6 +46,7 @@ function New-AzsComputeQuota {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsComputeQuota.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsComputeQuota.ps1
@@ -39,6 +39,7 @@ function Remove-AzsComputeQuota {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -48,6 +49,7 @@ function Remove-AzsComputeQuota {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlatformImage.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlatformImage.ps1
@@ -42,18 +42,22 @@ function Remove-AzsPlatformImage {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Offer,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Sku,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
@@ -63,6 +67,7 @@ function Remove-AzsPlatformImage {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsVMExtension.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsVMExtension.ps1
@@ -39,14 +39,17 @@ function Remove-AzsVMExtension {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Publisher,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Type,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Version,
 
@@ -56,6 +59,7 @@ function Remove-AzsVMExtension {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsComputeQuota.ps1
+++ b/src/StackAdmin/Azs.Compute.Admin/Module/Azs.Compute.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsComputeQuota.ps1
@@ -52,6 +52,7 @@ function Set-AzsComputeQuota {
     [CmdletBinding(DefaultParameterSetName = 'Update', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -76,10 +77,12 @@ function Set-AzsComputeQuota {
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Compute.Admin.Models.Quota]
         $InputObject,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Add-AzsScaleUnitNode.ps1
@@ -42,10 +42,12 @@ function Add-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'ScaleOut', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'ScaleOut')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ScaleUnitName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Fabric.Admin.Models.ScaleOutScaleUnitParameters[]]
         $NodeList,
 
@@ -64,6 +66,7 @@ function Add-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsInfrastructureRoleInstance.ps1
@@ -36,6 +36,7 @@ function Suspend-AzsInfrastructureRoleInstance {
     [CmdletBinding(DefaultParameterSetName = 'Shutdown', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Shutdown')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Suspend-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disable-AzsScaleUnitNode.ps1
@@ -36,6 +36,7 @@ function Disable-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'Disable', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Disable')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Disable-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Enable-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Enable-AzsScaleUnitNode.ps1
@@ -36,6 +36,7 @@ function Enable-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'Enable', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Enable')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Enable-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGateway.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGateway.ps1
@@ -49,6 +49,7 @@ function Get-AzsEdgeGateway {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsEdgeGateway {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGatewayPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsEdgeGatewayPool.ps1
@@ -49,6 +49,7 @@ function Get-AzsEdgeGatewayPool {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsEdgeGatewayPool {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureLocation.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureLocation.ps1
@@ -46,6 +46,7 @@ function Get-AzsInfrastructureLocation {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Location,
 
@@ -57,6 +58,7 @@ function Get-AzsInfrastructureLocation {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRole.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRole.ps1
@@ -49,6 +49,7 @@ function Get-AzsInfrastructureRole {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsInfrastructureRole {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureRoleInstance.ps1
@@ -49,6 +49,7 @@ function Get-AzsInfrastructureRoleInstance {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureShare.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureShare.ps1
@@ -42,6 +42,7 @@ function Get-AzsInfrastructureShare {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -58,6 +59,7 @@ function Get-AzsInfrastructureShare {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureVolume.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsInfrastructureVolume.ps1
@@ -55,16 +55,19 @@ function Get-AzsInfrastructureVolume {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $StoragePool,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $StorageSystem,
 
@@ -81,6 +84,7 @@ function Get-AzsInfrastructureVolume {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsIpPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsIpPool.ps1
@@ -51,6 +51,7 @@ function Get-AzsIpPool {
     param(
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -67,6 +68,7 @@ function Get-AzsIpPool {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalNetwork.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalNetwork.ps1
@@ -49,6 +49,7 @@ function Get-AzsLogicalNetwork {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsLogicalNetwork {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalSubnet.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLogicalSubnet.ps1
@@ -52,11 +52,13 @@ function Get-AzsLogicalSubnet {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $LogicalNetwork,
 
@@ -73,6 +75,7 @@ function Get-AzsLogicalSubnet {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsMacAddressPool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsMacAddressPool.ps1
@@ -49,6 +49,7 @@ function Get-AzsMacAddressPool {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsMacAddressPool {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnit.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnit.ps1
@@ -49,6 +49,7 @@ function Get-AzsScaleUnit {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsScaleUnit {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsScaleUnitNode.ps1
@@ -49,6 +49,7 @@ function Get-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -65,6 +66,7 @@ function Get-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSlbMuxInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSlbMuxInstance.ps1
@@ -50,6 +50,7 @@ function Get-AzsSlbMuxInstance {
     param(
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -66,6 +67,7 @@ function Get-AzsSlbMuxInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStoragePool.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStoragePool.ps1
@@ -53,11 +53,13 @@ function Get-AzsStoragePool {
     param(
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $StorageSystem,
 
@@ -74,6 +76,7 @@ function Get-AzsStoragePool {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageSystem.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageSystem.ps1
@@ -50,6 +50,7 @@ function Get-AzsStorageSystem {
     param(
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -66,6 +67,7 @@ function Get-AzsStorageSystem {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Repair-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Repair-AzsScaleUnitNode.ps1
@@ -39,10 +39,12 @@ function Repair-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'Repair', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Repair')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]
         $BMCIPv4Address,
 
@@ -57,6 +59,7 @@ function Repair-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRole.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRole.ps1
@@ -36,6 +36,7 @@ function Restart-AzsInfrastructureRole {
     [CmdletBinding(DefaultParameterSetName = 'Restart', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Restart')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Restart-AzsInfrastructureRole {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restart-AzsInfrastructureRoleInstance.ps1
@@ -37,6 +37,7 @@ function Restart-AzsInfrastructureRoleInstance {
     [CmdletBinding(DefaultParameterSetName = 'Restart', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Restart')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -51,6 +52,7 @@ function Restart-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsInfrastructureRoleInstance.ps1
@@ -36,6 +36,7 @@ function Start-AzsInfrastructureRoleInstance {
     [CmdletBinding(DefaultParameterSetName = 'PowerOn', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'PowerOn')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Start-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
@@ -38,6 +38,7 @@ function Start-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'PowerOn', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'PowerOn')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -52,6 +53,7 @@ function Start-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsScaleUnitNode.ps1
@@ -114,11 +114,11 @@ function Start-AzsScaleUnitNode {
 
         $FabricAdminClient = New-ServiceClient @NewServiceClient_params
 
-        if($Location -ne $null) {
+        if($Location -eq $null) {
             $Location = (Get-AzureRMLocation).Location
         }
 
-        if($ResourceGroupName -ne $null) {
+        if($ResourceGroupName -eq $null) {
             $ResourceGroupName = "System.$Location"
         }
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsInfrastructureRoleInstance.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsInfrastructureRoleInstance.ps1
@@ -36,6 +36,7 @@ function Stop-AzsInfrastructureRoleInstance {
     [CmdletBinding(DefaultParameterSetName = 'PowerOff', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'PowerOff')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,6 +51,7 @@ function Stop-AzsInfrastructureRoleInstance {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsScaleUnitNode.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Module/Azs.Fabric.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsScaleUnitNode.ps1
@@ -45,6 +45,7 @@ function Stop-AzsScaleUnitNode {
     [CmdletBinding(DefaultParameterSetName = 'Stop', SupportsShouldProcess=$true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Stop')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -59,6 +60,7 @@ function Stop-AzsScaleUnitNode {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Fabric.Admin/Tests/src/InfraRoleInstance.tests.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Tests/src/InfraRoleInstance.tests.ps1
@@ -149,7 +149,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$InfrastructureRoleInstances = Get-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($InfrastructureRoleInstance in $InfrastructureRoleInstances) {
-				Start-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name
+				Start-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name -Force
 				break
 			}
 		}
@@ -159,7 +159,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$InfrastructureRoleInstances = Get-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($InfrastructureRoleInstance in $InfrastructureRoleInstances) {
-				Start-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name
+				Start-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name -Force
 			}
 		}
 
@@ -176,21 +176,21 @@ InModuleScope Azs.Fabric.Admin {
 		It "TestInfrastructureRoleInstanceShutdownOnTenantVM" {
 			$global:TestName = 'TestInfrastructureRoleInstanceShutdownOnTenantVM'
 			{
-				Disable-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				Disable-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 			} | Should Throw
 		}
 
 		It "TestInfrastructureRoleInstanceRebootOnTenantVM" {
 			$global:TestName = 'TestInfrastructureRoleInstanceRebootOnTenantVM'
 			{
-				ReStart-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				Restart-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 		} | Should Throw
 		}
 
 		It "TestInfrastructureRoleInstancePowerOffOnTenantVM" {
 			$global:TestName = 'TestInfrastructureRoleInstancePowerOffOnTenantVM'
 			{
-				Stop-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				Stop-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 			} | Should Throw
 		}
 
@@ -202,7 +202,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$InfrastructureRoleInstances = Get-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($InfrastructureRoleInstance in $InfrastructureRoleInstances) {
-				Disable-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name
+				Disable-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name -Force
 				break
 			}
 		}
@@ -212,7 +212,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$InfrastructureRoleInstances = Get-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($InfrastructureRoleInstance in $InfrastructureRoleInstances) {
-				Stop-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name
+				Stop-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name -Force
 				break
 			}
 		}
@@ -222,7 +222,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$InfrastructureRoleInstances = Get-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($InfrastructureRoleInstance in $InfrastructureRoleInstances) {
-				ReStart-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name
+				Restart-AzsInfrastructureRoleInstance -ResourceGroupName $ResourceGroup -Location $Location -Name $InfrastructureRoleInstance.Name -Force
 				break
 			}
 		}

--- a/src/StackAdmin/Azs.Fabric.Admin/Tests/src/IpPool.tests.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Tests/src/IpPool.tests.ps1
@@ -148,7 +148,7 @@ InModuleScope Azs.Fabric.Admin {
 
 
 			$params = @($Location, $ResourceGroup, $Name, $StartIpAddress, $EndIpAddress, $AddressPrefix)
-			$ipPool = New-AzsIpPool @params
+			$ipPool = New-AzsIpPool @params -Force
 
 			$ipPool | Should not be $null
 		}

--- a/src/StackAdmin/Azs.Fabric.Admin/Tests/src/ScaleUnitNode.tests.ps1
+++ b/src/StackAdmin/Azs.Fabric.Admin/Tests/src/ScaleUnitNode.tests.ps1
@@ -160,7 +160,7 @@ InModuleScope Azs.Fabric.Admin {
 			$ScaleUnitNodes = Get-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location
 			foreach($ScaleUnitNode in $ScaleUnitNodes) {
 
-				Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name
+				Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name -Force
 				break
 			}
 		}
@@ -171,8 +171,8 @@ InModuleScope Azs.Fabric.Admin {
 			$ScaleUnitNodes = Get-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location
             foreach($ScaleUnitNode in $ScaleUnitNodes) {
 				{
-					Disable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name
-					Enable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name
+					Disable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name -Force
+					Enable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name -Force
 				} | Should Throw
 				break
             }
@@ -189,7 +189,7 @@ InModuleScope Azs.Fabric.Admin {
 		It "TestPowerOnOnTenantVM" {
 			$global:TestName = 'TestPowerOnOnTenantVM'
 			{
-				$operationStatus = Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				$operationStatus = Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 				$operationStatus.ProvisioningState | Should not be ""
 				$operationStatus.ProvisioningState | Should be "Failure"
 			} | Should Throw
@@ -199,7 +199,7 @@ InModuleScope Azs.Fabric.Admin {
 			$global:TestName = 'TestPowerOffOnTenantVM'
 
 			{
-				$operationStatus = Stop-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				$operationStatus = Stop-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 				$operationStatus.ProvisioningState | Should not be ""
 				$operationStatus.ProvisioningState | Should be "Failure"
 			} | Should Throw
@@ -208,7 +208,7 @@ InModuleScope Azs.Fabric.Admin {
 		It "TestStartMaintenanceModeOnTenantVM" {
 			$global:TestName = 'TestStartMaintenanceModeOnTenantVM'
 			{
-				$operationStatus = Disable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName
+				$operationStatus = Disable-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $TenantVMName -Force
 				$operationStatus.ProvisioningState | Should not be ""
 				$operationStatus.ProvisioningState | Should be "Failure"
 			} | Should Throw
@@ -222,7 +222,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$ScaleUnitNodes = Get-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location
             foreach($ScaleUnitNode in $ScaleUnitNodes) {
-                Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name
+                Start-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name -Force
 				$retrieved | Should Be $null
 				break
             }
@@ -233,7 +233,7 @@ InModuleScope Azs.Fabric.Admin {
 
 			$ScaleUnitNodes = Get-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location
             foreach($ScaleUnitNode in $ScaleUnitNodes) {
-                $retrieved = Stop-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name
+                $retrieved = Stop-AzsScaleUnitNode -ResourceGroupName $ResourceGroup -Location $Location -Name $ScaleUnitNode.Name -Force
 				$retrieved | Should Be $null
 				break
             }

--- a/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsGalleryItem.ps1
+++ b/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsGalleryItem.ps1
@@ -30,6 +30,7 @@ function Get-AzsGalleryItem {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name
     )

--- a/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsGalleryItem.ps1
+++ b/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsGalleryItem.ps1
@@ -24,6 +24,7 @@ function New-AzsGalleryItem {
     [CmdletBinding(DefaultParameterSetName = 'Create')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Create', Position = 0 )]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $GalleryItemUri
     )

--- a/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsGalleryItem.ps1
+++ b/src/StackAdmin/Azs.Gallery.Admin/Module/Azs.Gallery.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsGalleryItem.ps1
@@ -23,6 +23,7 @@ function Remove-AzsGalleryItem {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Close-AzsAlert.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Close-AzsAlert.ps1
@@ -45,6 +45,7 @@ function Close-AzsAlert {
     [OutputType([Microsoft.AzureStack.Management.InfrastructureInsights.Admin.Models.Alert])]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Close')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $AlertId,
 
@@ -62,10 +63,12 @@ function Close-AzsAlert {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.InfrastructureInsights.Admin.Models.Alert]
         $InputObject,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAlert.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAlert.ps1
@@ -50,6 +50,7 @@ function Get-AzsAlert {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $AlertId,
 
@@ -66,6 +67,7 @@ function Get-AzsAlert {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRPHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRPHealth.ps1
@@ -50,6 +50,7 @@ function Get-AzsRPHealth {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
         [Alias('ServiceHealth')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -66,6 +67,7 @@ function Get-AzsRPHealth {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegionHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegionHealth.ps1
@@ -40,6 +40,7 @@ function Get-AzsRegionHealth {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Location,
 
@@ -51,6 +52,7 @@ function Get-AzsRegionHealth {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegistrationHealth.ps1
+++ b/src/StackAdmin/Azs.InfrastructureInsights.Admin/Module/Azs.InfrastructureInsights.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsRegistrationHealth.ps1
@@ -54,10 +54,12 @@ function Get-AzsRegistrationHealth {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ServiceRegistrationId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceRegistrationId,
 
@@ -74,6 +76,7 @@ function Get-AzsRegistrationHealth {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsNetworkQuota.ps1
+++ b/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsNetworkQuota.ps1
@@ -39,6 +39,7 @@ function Get-AzsNetworkQuota {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -49,6 +50,7 @@ function Get-AzsNetworkQuota {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsNetworkQuota.ps1
+++ b/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsNetworkQuota.ps1
@@ -53,6 +53,7 @@ function New-AzsNetworkQuota {
     [CmdletBinding(DefaultParameterSetName = 'Quotas_CreateOrUpdate')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Quotas_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 

--- a/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsNetworkQuota.ps1
+++ b/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsNetworkQuota.ps1
@@ -42,6 +42,7 @@ function Remove-AzsNetworkQuota {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -51,6 +52,7 @@ function Remove-AzsNetworkQuota {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsNetworkQuota.ps1
+++ b/src/StackAdmin/Azs.Network.Admin/Module/Azs.Network.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsNetworkQuota.ps1
@@ -60,6 +60,7 @@ function Set-AzsNetworkQuota {
     [CmdletBinding(DefaultParameterSetName = 'Quotas')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Quotas')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -96,10 +97,12 @@ function Set-AzsNetworkQuota {
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Network.Admin.Models.Quota]
         $InputObject
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobService.ps1
@@ -28,6 +28,7 @@ function Get-AzsBlobService {
     [CmdletBinding(DefaultParameterSetName = 'Get')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetric.ps1
@@ -33,6 +33,7 @@ function Get-AzsBlobServiceMetric {
     [CmdletBinding(DefaultParameterSetName = 'ListMetrics')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'ListMetrics', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsBlobServiceMetricDefinition.ps1
@@ -34,6 +34,7 @@ function Get-AzsBlobServiceMetricDefinition {
     [CmdletBinding(DefaultParameterSetName = 'ListMetricDefinitions')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'ListMetricDefinitions', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDestinationShare.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDestinationShare.ps1
@@ -30,10 +30,12 @@ function Get-AzsDestinationShare {
     [CmdletBinding(DefaultParameterSetName = 'ListDestinationShares')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'ListDestinationShares')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $SourceShareName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ListDestinationShares')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueService.ps1
@@ -28,6 +28,7 @@ function Get-AzsQueueService {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetric.ps1
@@ -34,6 +34,7 @@ function Get-AzsQueueServiceMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsQueueServiceMetricDefinition.ps1
@@ -33,6 +33,7 @@ function Get-AzsQueueServiceMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsReclaimStorageCapacityStatus.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsReclaimStorageCapacityStatus.ps1
@@ -30,10 +30,12 @@ function Get-AzsReclaimStorageCapacityStatus {
     [CmdletBinding(DefaultParameterSetName = 'GetGarbageCollectionState')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'GetGarbageCollectionState')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'GetGarbageCollectionState')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $JobId,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAccount.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAccount.ps1
@@ -50,6 +50,7 @@ function Get-AzsStorageAccount {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAcquisition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageAcquisition.ps1
@@ -29,6 +29,7 @@ function Get-AzsStorageAcquisition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainer.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainer.ps1
@@ -35,10 +35,12 @@ function Get-AzsStorageContainer {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ShareName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageContainerMigration.ps1
@@ -34,10 +34,12 @@ function Get-AzsStorageContainerMigrationStatus {
     [CmdletBinding(DefaultParameterSetName = 'MigrationStatus')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'MigrationStatus')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'MigrationStatus')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $JobId,
 
@@ -47,6 +49,7 @@ function Get-AzsStorageContainerMigrationStatus {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [Alias('id')]
         [System.String]
         $ResourceId

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarm.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarm.ps1
@@ -37,6 +37,7 @@ function Get-AzsStorageFarm {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -48,6 +49,7 @@ function Get-AzsStorageFarm {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetric.ps1
@@ -34,6 +34,7 @@ function Get-AzsStorageFarmMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageFarmMetricDefinition.ps1
@@ -33,6 +33,7 @@ function Get-AzsStorageFarmMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageQuota.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageQuota.ps1
@@ -43,6 +43,7 @@ function Get-AzsStorageQuota {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $QuotaName,
 
@@ -53,6 +54,7 @@ function Get-AzsStorageQuota {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShare.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShare.ps1
@@ -35,10 +35,12 @@ function Get-AzsStorageShare {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ShareName,
 
@@ -49,6 +51,7 @@ function Get-AzsStorageShare {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetric.ps1
@@ -36,10 +36,12 @@ function Get-AzsStorageShareMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ShareName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsStorageShareMetricDefinition.ps1
@@ -36,10 +36,12 @@ function Get-AzsStorageShareMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ShareName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableService.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableService.ps1
@@ -27,6 +27,7 @@ function Get-AzsTableService {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetric.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetric.ps1
@@ -33,6 +33,7 @@ function Get-AzsTableServiceMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsTableServiceMetricDefinition.ps1
@@ -34,6 +34,7 @@ function Get-AzsTableServiceMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsStorageQuota.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsStorageQuota.ps1
@@ -34,6 +34,7 @@ function New-AzsStorageQuota {
     [CmdletBinding(DefaultParameterSetName = 'Create')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $QuotaName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsStorageQuota.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsStorageQuota.ps1
@@ -36,6 +36,7 @@ function Remove-AzsStorageQuota {
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
@@ -44,6 +45,7 @@ function Remove-AzsStorageQuota {
         $Location,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $QuotaName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsStorageAccount.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Restore-AzsStorageAccount.ps1
@@ -36,10 +36,12 @@ function Restore-AzsStorageAccount {
     [CmdletBinding(DefaultParameterSetName = 'Undelete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Undelete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Undelete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $AccountId,
 
@@ -50,6 +52,7 @@ function Restore-AzsStorageAccount {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsStorageQuota.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsStorageQuota.ps1
@@ -43,6 +43,7 @@ function Set-AzsStorageQuota {
 
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $QuotaName,
 
@@ -59,10 +60,12 @@ function Set-AzsStorageQuota {
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Storage.Admin.Models.StorageQuota]
         $InputObject,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsReclaimStorageCapacity.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsReclaimStorageCapacity.ps1
@@ -36,6 +36,7 @@ function Start-AzsReclaimStorageCapacity {
 
         [Parameter(Mandatory = $true)]
         [Alias('name')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsStorageContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Start-AzsStorageContainerMigration.ps1
@@ -42,14 +42,17 @@ function Start-AzsStorageContainerMigration {
     [CmdletBinding(DefaultParameterSetName = 'Migrate', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Migrate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $StorageAccountName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Migrate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $ContainerName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Migrate')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ShareName,
 
@@ -59,10 +62,12 @@ function Start-AzsStorageContainerMigration {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Migrate')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Migrate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $DestinationShareUncPath,
 

--- a/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsContainerMigration.ps1
+++ b/src/StackAdmin/Azs.Storage.Admin/Module/Azs.Storage.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Stop-AzsContainerMigration.ps1
@@ -35,6 +35,7 @@ function Stop-AzsContainerMigration {
     [CmdletBinding(DefaultParameterSetName = 'CancelMigration', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'CancelMigration')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $JobId,
 
@@ -45,10 +46,12 @@ function Stop-AzsContainerMigration {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'CancelMigration')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $FarmName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Connect-AzsPlanToOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Connect-AzsPlanToOffer.ps1
@@ -36,14 +36,17 @@ function Add-AzsPlanToOffer
     [CmdletBinding(DefaultParameterSetName='Offers_Link')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Link')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $PlanName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Link')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Link')]
+        [ValidateNotNullOrEmpty()]
         [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disconnect-AzsPlanToOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Disconnect-AzsPlanToOffer.ps1
@@ -36,14 +36,17 @@ function Remove-AzsPlanFromOffer
     [CmdletBinding(DefaultParameterSetName='Offers_Unlink')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Unlink')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $PlanName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Unlink')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_Unlink')]
+        [ValidateNotNullOrEmpty()]
         [ValidateLength(1, 90)]
         [System.String]
         $ResourceGroupName,

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAcquiredPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsAcquiredPlan.ps1
@@ -48,6 +48,7 @@ function Get-AzsAcquiredPlan {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProvider.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProvider.ps1
@@ -31,6 +31,7 @@ function Get-AzsDelegatedProvider
     [CmdletBinding(DefaultParameterSetName='List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DelegatedProviderId
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProviderManagedOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProviderManagedOffer.ps1
@@ -37,15 +37,18 @@ function Get-AzsDelegatedProviderManagedOffer {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DelegatedProvider,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDirectoryTenant.ps1
@@ -36,11 +36,13 @@ function Get-AzsDirectoryTenant {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLocation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsLocation.ps1
@@ -25,6 +25,7 @@ function Get-AzsLocation
     [CmdletBinding(DefaultParameterSetName='List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position=0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsManagedOffer.ps1
@@ -36,17 +36,20 @@ function Get-AzsManagedOffer {
     [CmdletBinding(DefaultParameterSetName = 'ListAll')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferDelegation.ps1
@@ -39,22 +39,26 @@ function Get-AzsOfferDelegation {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetric.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetric.ps1
@@ -28,11 +28,13 @@ function Get-AzsOfferMetric {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true)]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsOfferMetricDefinition.ps1
@@ -27,11 +27,13 @@ function Get-AzsOfferMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true)]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlan.ps1
@@ -50,6 +50,7 @@ function Get-AzsPlan {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetric.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetric.ps1
@@ -28,10 +28,12 @@ function Get-AzsPlanMetric {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $PlanName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetricDefinition.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsPlanMetricDefinition.ps1
@@ -27,11 +27,13 @@ function Get-AzsPlanMetricDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $PlanName,
 
         [Parameter(Mandatory = $true)]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscriptionsQuota.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscriptionsQuota.ps1
@@ -31,6 +31,7 @@ function Get-AzsSubscriptionsQuota {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -40,6 +41,7 @@ function Get-AzsSubscriptionsQuota {
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOffer.ps1
@@ -55,15 +55,18 @@ function New-AzsOffer {
     [CmdletBinding(DefaultParameterSetName = 'Offers_CreateOrUpdate')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $DisplayName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Offers_CreateOrUpdate')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsOfferDelegation.ps1
@@ -37,19 +37,23 @@ function New-AzsOfferDelegation {
     [CmdletBinding(DefaultParameterSetName = 'Create')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsPlan.ps1
@@ -50,19 +50,23 @@ function New-AzsPlan {
     [CmdletBinding(DefaultParameterSetName = 'Create')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $DisplayName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Create')]
+        [ValidateNotNullOrEmpty()]
         [string[]]
         $QuotaIds,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsUserSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsUserSubscription.ps1
@@ -56,10 +56,12 @@ function New-AzsUserSubscription
     [CmdletBinding(DefaultParameterSetName='Subscriptions_CreateOrUpdate')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Owner,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $OfferId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAcquiredPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsAcquiredPlan.ps1
@@ -38,10 +38,12 @@ function Remove-AzsAcquiredPlan {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $TargetSubscriptionId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsDirectoryTenant.ps1
@@ -32,16 +32,19 @@ function Remove-AzsDirectoryTenant {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOffer.ps1
@@ -32,16 +32,19 @@ function Remove-AzsOffer {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsOfferDelegation.ps1
@@ -35,20 +35,24 @@ function Remove-AzsOfferDelegation {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsPlan.ps1
@@ -32,16 +32,19 @@ function Remove-AzsPlan {
     [CmdletBinding(DefaultParameterSetName = 'Delete', SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Delete')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsDirectoryTenant.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsDirectoryTenant.ps1
@@ -40,6 +40,7 @@ function Set-AzsDirectoryTenant
     [CmdletBinding(DefaultParameterSetName='Update')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -47,6 +48,7 @@ function Set-AzsDirectoryTenant
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
@@ -63,10 +65,12 @@ function Set-AzsDirectoryTenant
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Subscriptions.Admin.Models.DirectoryTenant]
         $InputObject
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOffer.ps1
@@ -61,11 +61,13 @@ function Set-AzsOffer
     [CmdletBinding(DefaultParameterSetName='Update')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
@@ -107,6 +109,7 @@ function Set-AzsOffer
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InputObject')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Update')]
+        [Alias('ArmLocation')]
         [string]
         $Location,
 
@@ -129,6 +132,7 @@ function Set-AzsOffer
         $AddonPlanDefinition,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsOfferDelegation.ps1
@@ -43,15 +43,18 @@ function Set-AzsOfferDelegation
     [CmdletBinding(DefaultParameterSetName='Update')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
@@ -62,6 +65,7 @@ function Set-AzsOfferDelegation
         $SubscriptionId,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 
@@ -72,6 +76,7 @@ function Set-AzsOfferDelegation
         $Location,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Subscriptions.Admin.Models.OfferDelegation]
         $InputObject
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsPlan.ps1
@@ -56,11 +56,13 @@ function Set-AzsPlan
     [CmdletBinding(DefaultParameterSetName='Update')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
         [ValidateLength(1, 90)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceGroupName,
 
@@ -77,6 +79,7 @@ function Set-AzsPlan
         $QuotaIds,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'InputObject')]
+        [ValidateNotNullOrEmpty()]
         [Microsoft.AzureStack.Management.Subscriptions.Admin.Models.Plan]
         $InputObject,
 
@@ -101,6 +104,7 @@ function Set-AzsPlan
         [Parameter(Mandatory = $false, ParameterSetName = 'Update')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InputObject')]
+        [Alias('ArmLocation')]
         [string]
         $Location,
 
@@ -111,6 +115,7 @@ function Set-AzsPlan
         $SubscriptionCount,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsUserSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsUserSubscription.ps1
@@ -57,6 +57,7 @@ function Set-AzsUserSubscription {
         [ValidateScript( {
                 [System.Guid]::TryParse($SubscriptionId)
             })]
+            [ValidateNotNullOrEmpty()]
         [System.Guid]
         $SubscriptionId,
 

--- a/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Test-AzsNameAvailability.ps1
+++ b/src/StackAdmin/Azs.Subscriptions.Admin/Module/Azs.Subscriptions.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Test-AzsNameAvailability.ps1
@@ -27,10 +27,12 @@ function Test-AzsNameAvailability {
     [CmdletBinding(DefaultParameterSetName = 'Subscriptions_CheckNameAvailability')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CheckNameAvailability')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CheckNameAvailability')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $ResourceType
     )

--- a/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProviderOffer.ps1
+++ b/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsDelegatedProviderOffer.ps1
@@ -34,11 +34,13 @@ function Get-AzsDelegatedProviderOffer
     [CmdletBinding(DefaultParameterSetName='List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $OfferName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DelegatedProviderId,
 

--- a/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsSubscription.ps1
@@ -25,6 +25,7 @@ function Get-AzsSubscription
     [CmdletBinding(DefaultParameterSetName='List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $SubscriptionId
     )

--- a/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/New-AzsSubscription.ps1
@@ -49,6 +49,7 @@ function New-AzsSubscription
     [CmdletBinding(DefaultParameterSetName='Subscriptions_CreateOrUpdate')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $OfferId,
 

--- a/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Remove-AzsSubscription.ps1
@@ -24,6 +24,7 @@ function Remove-AzsSubscription {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $SubscriptionId,
 

--- a/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsSubscription.ps1
+++ b/src/StackAdmin/Azs.Subscriptions/Module/Azs.Subscriptions/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsSubscription.ps1
@@ -49,6 +49,7 @@ function Set-AzsSubscription
     [CmdletBinding(DefaultParameterSetName='Subscriptions_CreateOrUpdate')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $OfferId,
 
@@ -65,11 +66,13 @@ function Set-AzsSubscription
         $Tags,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Subscriptions_CreateOrUpdate')]
         [ValidateSet('NotDefined', 'Enabled', 'Warned', 'PastDue', 'Disabled', 'Deleted')]
+        [ValidateNotNullOrEmpty()]
         [string]
         $State,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdate.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdate.ps1
@@ -47,6 +47,7 @@ function Get-AzsUpdate {
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get', Position = 0)]
         [Alias('Update')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -63,6 +64,7 @@ function Get-AzsUpdate {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateLocation.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateLocation.ps1
@@ -40,6 +40,7 @@ function Get-AzsUpdateLocation {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId
     )

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateRun.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Get-AzsUpdateRun.ps1
@@ -45,11 +45,13 @@ function Get-AzsUpdateRun {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'List')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Get')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
 
@@ -66,6 +68,7 @@ function Get-AzsUpdateRun {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Install-AzsUpdate.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Install-AzsUpdate.ps1
@@ -46,6 +46,7 @@ function Install-AzsUpdate {
         $Location,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Apply')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -55,6 +56,7 @@ function Install-AzsUpdate {
 
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 

--- a/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Resume-AzsUpdateRun.ps1
+++ b/src/StackAdmin/Azs.Update.Admin/Module/Azs.Update.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Resume-AzsUpdateRun.ps1
@@ -38,6 +38,7 @@ function Resume-AzsUpdateRun {
     [CmdletBinding(DefaultParameterSetName = 'UpdateRuns_Rerun')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'UpdateRuns_Rerun')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -51,6 +52,7 @@ function Resume-AzsUpdateRun {
         $ResourceGroupName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'UpdateRuns_Rerun')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DisplayName,
 
@@ -60,6 +62,7 @@ function Resume-AzsUpdateRun {
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'ResourceId')]
         [Alias('id')]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ResourceId,
 


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Added check for not null or empty for mandatory parameters; 
Added alias for 'Location' parameter as 'ArmLocation' in subscription admin module (New-AzsOffer/New-AzsPlan/Set-AzsOffer

## Checklist

- [ ] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [ ] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)
